### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,17 +1,21 @@
-cmake_minimum_required(VERSION 3.15.1)
+cmake_minimum_required(VERSION 3.18)
 
-project(cxx-support LANGUAGES CXX)
+project(cxx-interopt-test LANGUAGES CXX Swift)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED YES)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 add_library(cxx-support Sources/CXX/CXX.cpp)
 target_compile_options(cxx-support PRIVATE
-  -c -std=c++11 -nostdinc++)
+  -nostdinc++)
+target_include_directories(cxx-support PUBLIC
+  ${CMAKE_SOURCE_DIR}/Sources/CXX/include)
 
-project(cxx-interop-test LANGUAGES Swift)
 add_executable(cxx-interop-test Sources/Swift/main.swift)
-add_dependencies(cxx-interop-test cxx-support)
 target_compile_options(cxx-interop-test PRIVATE
-  -I${CMAKE_SOURCE_DIR}/Sources/CXX/include
-  libcxx-support.a
   "SHELL:-Xfrontend -enable-cxx-interop"
   "SHELL:-Xfrontend -validate-tbd-against-ir=none"
   "SHELL:-Xcc -nostdinc++"
   -lc++)
+target_link_libraries(cxx-interop-test PRIVATE cxx-support)


### PR DESCRIPTION
- Bump CMake to 3.18
  There have been a bunch of improvements to CMake's Swift support, require at least CMake 3.18
- Use a single project
  A CMakeLists.txt should generally have a single project.  This adjusts the build to use that pattern.
- Use CMake to setup the C++ standard
  This ensures that we use `/std:c++11` or `-std=c++11` based on the driver (`clang-cl` is a support interop compiler)
- Use `target_link_libraries` for adding the dependency and link flags
- Use `target_include_directories` to handle the include paths